### PR TITLE
support for different project types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # qmd_ctutypst
+
+A typical qmd header for this format might look like this
+
+```
+---
+format: qmd_ctutypst-typst
+title: "Report Title"         # name of the report
+subtitle: ""                  # subtitle - typically the project name
+project_type: "Project"       # project type - typically Project or Consulting
+projectno: "1837"             # project number
+logo: "dcrlogo.jpg"           # logo name
+logo_size: 200%               # size of the logo in percent (or auto) 
+path_logo: "path-to-file"     # path to the logo file
+author:                       # author details, only name, affiliation and email are used
+    - name: "André Moser"
+      affiliation: "Department of Clinical Research, University of Bern"
+      email: "andre.moser@unibe.ch"
+toc: false                    # include table of contents
+paper-size: a4                # paper size
+heading: true                 # include numbering in headers/sections
+heading-numbering: "1.1.1"    # how to format header/section numbers
+---
+```
  

--- a/_extensions/extensions/qmd_ctutypst/typst-show.typ
+++ b/_extensions/extensions/qmd_ctutypst/typst-show.typ
@@ -38,4 +38,9 @@ $endif$
 $else$
   heading-numbering: none,
 $endif$
+$if(project_type)$
+  project_type: "$project_type$",
+$else$
+  project_type: "Project",
+$endif$
 )

--- a/_extensions/extensions/qmd_ctutypst/typst-template.typ
+++ b/_extensions/extensions/qmd_ctutypst/typst-template.typ
@@ -24,6 +24,7 @@
   paper-size: "a4",
   font-face: "Arial",
   heading-numbering: "1.1.1",
+  project_type: "Project",
   body,
 ) = {
 
@@ -70,8 +71,7 @@
   v(0.01fr)
   // Set project number
   if projectno != none {
-  text(size: 14pt, "Project number: ")
-  text(size: 14pt, projectno)
+  text(size: 14pt, project_type + " number: " + projectno)
   }
   v(0.01fr)
   


### PR DESCRIPTION
Allows passing a custom text for inclusion on the first page in place of `Project` (e.g. `Consulting`)
Also added some documentation of the options. 
Is it worth setting the `logo` default to `"dcrlogo.jpg"`? 